### PR TITLE
Remove trailing commas from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-  language: java,
-  sudo: required,
-  group: stable,
-  dist: precise,
+  language: java
+  sudo: required
+  group: stable
+  dist: precise
   os: linux


### PR DESCRIPTION
Hi!

I work at travis and saw this repo pop up in our error logs, looks like the comma at the end of these two lines is preventing the build from starting correctly.

I hope this PR helps fix that!

There might still be some other things left to figure out, but this should give you some log output to go from. ✨